### PR TITLE
Final Group Capstone - Mentor Me Now - Front-end: Implemented the required changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Setup](#setup)
   - [Install](#install)
 - [Usage](#usage)
+- [Kanban Board](#kanban-board)
 - [Author](#author)
 - [Future Features](#future-features)
 - [Contributing](#contributing)
@@ -107,6 +108,11 @@ Open `http://localhost:5173/` to view it in your browser.
 
 Ensure the **MentorMeNow Backend** app is running to fetch data successfully. For details on running the **MentorMeNow Backend** app, refer to its [README](https://github.com/Ayokunnumi1/mentor_me_now_back_end).
 
+
+## Kanban Board <a name="kanban-board"></a>
+- [Kanban board link](https://github.com/users/martinkarugaba/projects/11/views/1)
+- [Kanban board initial state](./kabanboardinitialstate.png)
+- We are a team of 3 members as indicated in the authors section
 
 ## Author <a name="author"></a>
 

--- a/src/components/MentorDetails.jsx
+++ b/src/components/MentorDetails.jsx
@@ -93,7 +93,7 @@ const MentorDetails = () => {
           </section>
           <div className="h-auto mt-12 lg:mt-auto flex justify-center items-center">
             <Link
-              to="/mentors"
+              to="/reserveMentor"
               className="py-4 px-6 w-[200px] text-center rounded-full bg-primary-green text-white font-bold text-xl"
             >
               Reserve


### PR DESCRIPTION
This branch has already undergone review in [this PR](https://github.com/martinkarugaba/mentor_me_now_front_end/pull/41). It was established to address the modifications suggested by the previous reviewer.

## Modifications Implemented:
- Corrected the link for the `reserve` button on the Mentor details page.
- Included a link to the Kanban Board and an image of the initial state.


[Here is the link of the Back end PR](https://github.com/Ayokunnumi1/mentor_me_now_back_end/pull/14)